### PR TITLE
OpenAIRE Jan 2024 snapshot

### DIFF
--- a/database/schemas/communities_infrastructures.json
+++ b/database/schemas/communities_infrastructures.json
@@ -1,44 +1,44 @@
 [
-{ 
+  {
     "description": "OpenAIRE id of the research community/research infrastructure",
     "name": "id",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "The acronym of the community",
     "name": "acronym",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "The long name of the community",
     "name": "name",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "One of {Research Community, Research infrastructure}",
     "name": "type",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "Description of the research community/research infrastructure",
     "name": "description",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "The URL of the Zenodo community associated to the Research community/Research infrastructure",
     "name": "zenodo_community",
     "type": "STRING",
     "mode": "NULLABLE"
-},
-{ 
+  },
+  {
     "description": "Only for research communities: the list of the subjects associated to the research community",
-    "name": "subject", 
+    "name": "subject",
     "type": "STRING",
     "mode": "REPEATED"
-}
+  }
 ]

--- a/database/schemas/dataset.json
+++ b/database/schemas/dataset.json
@@ -1,583 +1,603 @@
 [
-    {
-      "name": "version",
-      "description": "Explanatory or alternative name by which a scientific result is known.",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "subtitle",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "id",
-      "description": "The OpenAIRE identifiers for this result",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "instance",
-      "description": "Each instance is one specific materialisation or version of the result. For example, you can have one result with three instance: one is the pre-print, one is the post-print, one is te published version",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "refereed",
-          "description": "If this instance has been peer-reviewed or not. Allowed values are peerReviewed, nonPeerReviewed, UNKNOWN (as defined in https://api.openaire.eu/vocabularies/dnet:review_levels)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "accessright",
-          "description": "The accessRights for this materialization of the result",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "openAccessRoute",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "scheme",
-              "description": "Scheme of reference for access right code. Always set to COAR access rights vocabulary: http://vocabularies.coar-repositories.org/documentation/access_rights/",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "label",
-              "description": "Label for the access mode",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "code",
-              "description": "COAR access mode code: http://vocabularies.coar-repositories.org/documentation/access_rights/",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        },
-        {
-          "name": "license",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "publicationdate",
-          "description": "Date of the research product",
-          "mode": "NULLABLE",
-          "type": "DATE"
-        },
-        {
-          "name": "type",
-          "description": "Type of the result: one of 'publication', 'dataset', 'software', 'other' (see also https://api.openaire.eu/vocabularies/dnet:result_typologies)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "url",
-          "mode": "REPEATED",
-          "type": "STRING"
-        },
-        {
-          "name": "alternateIdentifier",
-          "description": "All the identifiers other than pids forged by an authorithy for the pid type (i.e. Crossref for DOIs",
-          "mode": "REPEATED",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "value",
-              "description": "The value expressed in the scheme",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "scheme",
-              "description": "The scheme of the identifier. It can be a persistent identifier (i.e. doi). If it is present in the alternate identifiers it means it has not been forged by an authority for that pid. For example we collect metadata from an institutional repository that provides as identifier for the result also the doi",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        },
-        {
-          "name": "pid",
-          "mode": "REPEATED",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "value",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "scheme",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "maintitle",
-      "description": "A name or title by which a scientific result is known. May be the title of a publication, of a dataset or the name of a piece of software.",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "indicators",
-      "description": "Indicators computed for this result, for example UsageCount ones",
-      "mode": "NULLABLE",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "bipIndicators",
-          "mode": "REPEATED",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "indicator",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "class",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "score",
-              "mode": "NULLABLE",
-              "type": "FLOAT"
-            }
-           ]
-        },
-        {
-          "name": "impactMeasures",
-          "description": "The impact measures (i.e. popularity)",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "influence_alt",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "class",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "score",
-                  "mode": "NULLABLE",
-                  "type": "INTEGER"
-                }
-              ]
-            },
-            {
-              "name": "impulse",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "class",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "score",
-                  "mode": "NULLABLE",
-                  "type": "INTEGER"
-                }
-              ]
-            },
-            {
-              "name": "popularity_alt",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "class",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "score",
-                  "mode": "NULLABLE",
-                  "type": "FLOAT"
-                }
-              ]
-            },
-            {
-              "name": "popularity",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "class",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "score",
-                  "mode": "NULLABLE",
-                  "type": "FLOAT"
-                }
-              ]
-            },
-            {
-              "name": "influence",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "class",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "score",
-                  "mode": "NULLABLE",
-                  "type": "FLOAT"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "usageCounts",
-          "description": "The usage counts (i.e. downloads)",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "views",
-              "mode": "NULLABLE",
-              "type": "INTEGER"
-            },
-            {
-              "name": "downloads",
-              "mode": "NULLABLE",
-              "type": "INTEGER"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "publicationdate",
-      "description": "Date of the research product",
-      "mode": "NULLABLE",
-      "type": "DATE"
-    },
-    {
-      "name": "size",
-      "description": "Only for results with type 'dataset': the declared size of the dataset",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "lastupdatetimestamp",
-      "description": "Timestamp of last update of the record in OpenAIRE",
-      "mode": "NULLABLE",
-      "type": "INTEGER"
-    },
-    {
-      "name": "originalId",
-      "description": "Identifiers of the record at the original sources",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "dateofcollection",
-      "description": "When OpenAIRE collected the record the last time",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "language",
-      "mode": "NULLABLE",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "label",
-          "description": "Language label in English",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "code",
-          "description": "alpha-3/ISO 639-2 code of the language",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "pid",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "value",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "scheme",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "geolocation",
-      "description": "Geolocation information",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "box",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "place",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "point",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "bestaccessright",
-      "description": "The openest of the access rights of this result.",
-      "mode": "NULLABLE",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "scheme",
-          "description": "Scheme of reference for access right code. Always set to COAR access rights vocabulary: http://vocabularies.coar-repositories.org/documentation/access_rights/",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "label",
-          "description": "Label for the access mode",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "code",
-          "description": "COAR access mode code: http://vocabularies.coar-repositories.org/documentation/access_rights/",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "coverage",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "contributor",
-      "description": "Contributors for the result",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "source",
-      "description": "See definition of Dublin Core field dc:source",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "subjects",
-      "description": "Keywords associated to the result",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "provenance",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "trust",
-              "mode": "NULLABLE",
-              "type": "FLOAT"
-            },
-            {
-              "name": "provenance",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        },
-        {
-          "name": "subject",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "value",
-              "description": "The value for the subject in the selected scheme.  When the scheme is 'keyword', it means that the subject is free-text (i.e. not a term from a controlled vocabulary).",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            },
-            {
-              "name": "scheme",
-              "description": "OpenAIRE subject classification scheme (https://api.openaire.eu/vocabularies/dnet:subject_classification_typologies).",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "format",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "publisher",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "description",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "country",
-      "description": "The list of countries associated to this result",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "label",
-          "description": "The label for that code (i.e. Italy)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "provenance",
-          "description": "Why this result is associated to the country.",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "trust",
-              "mode": "NULLABLE",
-              "type": "FLOAT"
-            },
-            {
-              "name": "provenance",
-              "mode": "NULLABLE",
-              "type": "STRING"
-            }
-          ]
-        },
-        {
-          "name": "code",
-          "description": "ISO 3166-1 alpha-2 country code (i.e. IT)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "type",
-      "description": "Type of the result: one of 'publication', 'dataset', 'software', 'other' (see also https://api.openaire.eu/vocabularies/dnet:result_typologies)",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "embargoenddate",
-      "description": "Date when the embargo ends and this result turns Open Access",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "author",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "pid",
-          "description": "The author's persistent identifiers",
-          "mode": "NULLABLE",
-          "type": "RECORD",
-          "fields": [
-            {
-              "name": "provenance",
-              "description": "The reason why the pid was associated to the author",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "trust",
-                  "mode": "NULLABLE",
-                  "type": "FLOAT"
-                },
-                {
-                  "name": "provenance",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                }
-              ]
-            },
-            {
-              "name": "id",
-              "mode": "NULLABLE",
-              "type": "RECORD",
-              "fields": [
-                {
-                  "name": "value",
-                  "description": "The author's pid value in that scheme (i.e. 0000-1111-2222-3333)",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                },
-                {
-                  "name": "scheme",
-                  "description": "The author's pid scheme.  OpenAIRE currently supports 'ORCID'",
-                  "mode": "NULLABLE",
-                  "type": "STRING"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "rank",
-          "mode": "NULLABLE",
-          "type": "INTEGER"
-        },
-        {
-          "name": "name",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "surname",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "fullname",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    }
-  ]
+  {
+    "name": "version",
+    "description": "Explanatory or alternative name by which a scientific result is known.",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "subtitle",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "id",
+    "description": "The OpenAIRE identifiers for this result",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "instance",
+    "description": "Each instance is one specific materialisation or version of the result. For example, you can have one result with three instance: one is the pre-print, one is the post-print, one is te published version",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "refereed",
+        "description": "If this instance has been peer-reviewed or not. Allowed values are peerReviewed, nonPeerReviewed, UNKNOWN (as defined in https://api.openaire.eu/vocabularies/dnet:review_levels)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "accessright",
+        "description": "The accessRights for this materialization of the result",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "openAccessRoute",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "scheme",
+            "description": "Scheme of reference for access right code. Always set to COAR access rights vocabulary: http://vocabularies.coar-repositories.org/documentation/access_rights/",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "label",
+            "description": "Label for the access mode",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "code",
+            "description": "COAR access mode code: http://vocabularies.coar-repositories.org/documentation/access_rights/",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      },
+      {
+        "name": "license",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "publicationdate",
+        "description": "Date of the research product",
+        "mode": "NULLABLE",
+        "type": "DATE"
+      },
+      {
+        "name": "type",
+        "description": "Type of the result: one of 'publication', 'dataset', 'software', 'other' (see also https://api.openaire.eu/vocabularies/dnet:result_typologies)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "url",
+        "mode": "REPEATED",
+        "type": "STRING"
+      },
+      {
+        "name": "alternateIdentifier",
+        "description": "All the identifiers other than pids forged by an authorithy for the pid type (i.e. Crossref for DOIs",
+        "mode": "REPEATED",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "value",
+            "description": "The value expressed in the scheme",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "scheme",
+            "description": "The scheme of the identifier. It can be a persistent identifier (i.e. doi). If it is present in the alternate identifiers it means it has not been forged by an authority for that pid. For example we collect metadata from an institutional repository that provides as identifier for the result also the doi",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      },
+      {
+        "name": "pid",
+        "mode": "REPEATED",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "value",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "scheme",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "maintitle",
+    "description": "A name or title by which a scientific result is known. May be the title of a publication, of a dataset or the name of a piece of software.",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "indicators",
+    "description": "Indicators computed for this result, for example UsageCount ones",
+    "mode": "NULLABLE",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "bipIndicators",
+        "mode": "REPEATED",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "indicator",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "class",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "score",
+            "mode": "NULLABLE",
+            "type": "FLOAT"
+          }
+        ]
+      },
+      {
+        "name": "impactMeasures",
+        "description": "The impact measures (i.e. popularity)",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "influence_alt",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "class",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "score",
+                "mode": "NULLABLE",
+                "type": "INTEGER"
+              }
+            ]
+          },
+          {
+            "name": "impulse",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "class",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "score",
+                "mode": "NULLABLE",
+                "type": "INTEGER"
+              }
+            ]
+          },
+          {
+            "name": "popularity_alt",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "class",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "score",
+                "mode": "NULLABLE",
+                "type": "FLOAT"
+              }
+            ]
+          },
+          {
+            "name": "popularity",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "class",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "score",
+                "mode": "NULLABLE",
+                "type": "FLOAT"
+              }
+            ]
+          },
+          {
+            "name": "influence",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "class",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "score",
+                "mode": "NULLABLE",
+                "type": "FLOAT"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "usageCounts",
+        "description": "The usage counts (i.e. downloads)",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "views",
+            "mode": "NULLABLE",
+            "type": "INTEGER"
+          },
+          {
+            "name": "downloads",
+            "mode": "NULLABLE",
+            "type": "INTEGER"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "publicationdate",
+    "description": "Date of the research product",
+    "mode": "NULLABLE",
+    "type": "DATE"
+  },
+  {
+    "name": "size",
+    "description": "Only for results with type 'dataset': the declared size of the dataset",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "lastupdatetimestamp",
+    "description": "Timestamp of last update of the record in OpenAIRE",
+    "mode": "NULLABLE",
+    "type": "INTEGER"
+  },
+  {
+    "name": "originalId",
+    "description": "Identifiers of the record at the original sources",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "dateofcollection",
+    "description": "When OpenAIRE collected the record the last time",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "language",
+    "mode": "NULLABLE",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "label",
+        "description": "Language label in English",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "code",
+        "description": "alpha-3/ISO 639-2 code of the language",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "pid",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "value",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "scheme",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "geolocation",
+    "description": "Geolocation information",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "box",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "place",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "point",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "bestaccessright",
+    "description": "The openest of the access rights of this result.",
+    "mode": "NULLABLE",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "scheme",
+        "description": "Scheme of reference for access right code. Always set to COAR access rights vocabulary: http://vocabularies.coar-repositories.org/documentation/access_rights/",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "label",
+        "description": "Label for the access mode",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "code",
+        "description": "COAR access mode code: http://vocabularies.coar-repositories.org/documentation/access_rights/",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "coverage",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "contributor",
+    "description": "Contributors for the result",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "source",
+    "description": "See definition of Dublin Core field dc:source",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "subjects",
+    "description": "Keywords associated to the result",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "provenance",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "trust",
+            "mode": "NULLABLE",
+            "type": "FLOAT"
+          },
+          {
+            "name": "provenance",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      },
+      {
+        "name": "subject",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "value",
+            "description": "The value for the subject in the selected scheme.  When the scheme is 'keyword', it means that the subject is free-text (i.e. not a term from a controlled vocabulary).",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          },
+          {
+            "name": "scheme",
+            "description": "OpenAIRE subject classification scheme (https://api.openaire.eu/vocabularies/dnet:subject_classification_typologies).",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "format",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "publisher",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "description",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "country",
+    "description": "The list of countries associated to this result",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "label",
+        "description": "The label for that code (i.e. Italy)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "provenance",
+        "description": "Why this result is associated to the country.",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "trust",
+            "mode": "NULLABLE",
+            "type": "FLOAT"
+          },
+          {
+            "name": "provenance",
+            "mode": "NULLABLE",
+            "type": "STRING"
+          }
+        ]
+      },
+      {
+        "name": "code",
+        "description": "ISO 3166-1 alpha-2 country code (i.e. IT)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "type",
+    "description": "Type of the result: one of 'publication', 'dataset', 'software', 'other' (see also https://api.openaire.eu/vocabularies/dnet:result_typologies)",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "embargoenddate",
+    "description": "Date when the embargo ends and this result turns Open Access",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "author",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "pid",
+        "description": "The author's persistent identifiers",
+        "mode": "NULLABLE",
+        "type": "RECORD",
+        "fields": [
+          {
+            "name": "provenance",
+            "description": "The reason why the pid was associated to the author",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "trust",
+                "mode": "NULLABLE",
+                "type": "FLOAT"
+              },
+              {
+                "name": "provenance",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              }
+            ]
+          },
+          {
+            "name": "id",
+            "mode": "NULLABLE",
+            "type": "RECORD",
+            "fields": [
+              {
+                "name": "value",
+                "description": "The author's pid value in that scheme (i.e. 0000-1111-2222-3333)",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              },
+              {
+                "name": "scheme",
+                "description": "The author's pid scheme.  OpenAIRE currently supports 'ORCID'",
+                "mode": "NULLABLE",
+                "type": "STRING"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "rank",
+        "mode": "NULLABLE",
+        "type": "INTEGER"
+      },
+      {
+        "name": "name",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "surname",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "fullname",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "isGreen",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "openAccessColor",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "isInDiamondJournal",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "publiclyFunded",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  }
+]

--- a/database/schemas/datasource.json
+++ b/database/schemas/datasource.json
@@ -1,245 +1,245 @@
 [
-    {
-      "name": "databaseaccessrestriction",
-      "description": "Access restrinctions to the data source, as defined by re3data.org. One of {feeRequired, registration, other}",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "dateofvalidation",
-      "description": "The date of last validation against the OpenAIRE guidelines for the datasource records",
-      "mode": "NULLABLE",
-      "type": "DATE"
-    },
-    {
-      "name": "id",
-      "description": "The OpenAIRE id of the data source",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "pidsystems",
-      "description": "The persistent identifier system that is used by the data source. As defined by re3data.org",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "citationguidelineurl",
-      "description": "The URL of the data source providing information on how to cite its items. As defined by re3data.org.",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "versioning",
-      "description": "As defined by redata.org: 'yes' if the data source supports versioning, 'no' otherwise.",
-      "mode": "NULLABLE",
-      "type": "BOOLEAN"
-    },
-    {
-      "name": "missionstatementurl",
-      "description": "The URL of a mission statement describing the designated community of the data source. As defined by re3data.org",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "languages",
-      "description": "The languages present in the data source's content, as defined by OpenDOAR.",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "accessrights",
-      "description": "Type of access to the data source, as defined by re3data.org. Possible values: {open, restricted, closed}",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "journal",
-      "description": "Information about the journal, if this data source is of type Journal.",
-      "mode": "NULLABLE",
-      "type": "RECORD",
-      "fields": [
-        {
-            "name": "conferencedate",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-            "name": "conferenceplace",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-            "name": "edition",
-            "description": "Edition of the journal or conference proceeding",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-            "name": "ep",
-            "description": "End page",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-            "name": "iss",
-            "description": "Journal issue number",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-          "name": "issnLinking",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-            "name": "issnOnline",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-          "name": "issnPrinted",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "name",
-          "description": "Name of the journal or conference",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-            "name": "sp",
-            "description": "Start page",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        },
-        {
-            "name": "vol",
-            "description": "vol",
-            "mode": "NULLABLE",
-            "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "websiteurl",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "subjects",
-      "description": "List of subjects associated to the datasource",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "policies",
-      "description": "Policies of the data source, as defined in OpenDOAR.",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "logourl",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "originalId",
-      "description": "Original identifiers for the datasource",
-      "mode": "REPEATED",
-      "type": "STRING"
-    },
-    {
-      "name": "officialname",
-      "description": "The official name of the datasource",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "datauploadrestriction",
-      "description": "Upload restrictions applied by the datasource, as defined by re3data.org. One of {feeRequired, registration, other}",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "datasourcetype",
-      "mode": "NULLABLE",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "value",
-          "description": "The value expressed in the scheme (Journal)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "scheme",
-          "description": "The scheme used to express the value (i.e. pubsrepository::journal)",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "openairecompatibility",
-      "description": "OpenAIRE guidelines the data source comply with. See also https://guidelines.openaire.eu.",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "uploadrights",
-      "description": "Type of data upload. As defined by re3data.org: one of {open, restricted,closed}",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "description",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "englishname",
-      "description": "The English name of the datasource",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "releaseenddate",
-      "description": "Date when the data source went offline or stopped ingesting new research data. As defined by re3data.org",
-      "mode": "NULLABLE",
-      "type": "DATE"
-    },
-    {
-      "name": "releasestartdate",
-      "description": "Releasing date of the data source, as defined by re3data.org",
-      "mode": "NULLABLE",
-      "type": "DATE"
-    },
-    {
-      "name": "certificates",
-      "description": "The certificate, seal or standard the data source complies with. As defined by re3data.org.",
-      "mode": "NULLABLE",
-      "type": "STRING"
-    },
-    {
-      "name": "pid",
-      "description": "Persistent identifiers of the datasource",
-      "mode": "REPEATED",
-      "type": "RECORD",
-      "fields": [
-        {
-          "name": "value",
-          "description": "The value expressed in the scheme ",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
-        {
-          "name": "scheme",
-          "description": "The scheme used to express the value ",
-          "mode": "NULLABLE",
-          "type": "STRING"
-        }
-      ]
-    }
-  ]
+  {
+    "name": "databaseaccessrestriction",
+    "description": "Access restrinctions to the data source, as defined by re3data.org. One of {feeRequired, registration, other}",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "dateofvalidation",
+    "description": "The date of last validation against the OpenAIRE guidelines for the datasource records",
+    "mode": "NULLABLE",
+    "type": "DATE"
+  },
+  {
+    "name": "id",
+    "description": "The OpenAIRE id of the data source",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "pidsystems",
+    "description": "The persistent identifier system that is used by the data source. As defined by re3data.org",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "citationguidelineurl",
+    "description": "The URL of the data source providing information on how to cite its items. As defined by re3data.org.",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "versioning",
+    "description": "As defined by redata.org: 'yes' if the data source supports versioning, 'no' otherwise.",
+    "mode": "NULLABLE",
+    "type": "BOOLEAN"
+  },
+  {
+    "name": "missionstatementurl",
+    "description": "The URL of a mission statement describing the designated community of the data source. As defined by re3data.org",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "languages",
+    "description": "The languages present in the data source's content, as defined by OpenDOAR.",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "accessrights",
+    "description": "Type of access to the data source, as defined by re3data.org. Possible values: {open, restricted, closed}",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "journal",
+    "description": "Information about the journal, if this data source is of type Journal.",
+    "mode": "NULLABLE",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "conferencedate",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "conferenceplace",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "edition",
+        "description": "Edition of the journal or conference proceeding",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "ep",
+        "description": "End page",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "iss",
+        "description": "Journal issue number",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "issnLinking",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "issnOnline",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "issnPrinted",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "Name of the journal or conference",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "sp",
+        "description": "Start page",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "vol",
+        "description": "vol",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "websiteurl",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "subjects",
+    "description": "List of subjects associated to the datasource",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "policies",
+    "description": "Policies of the data source, as defined in OpenDOAR.",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "logourl",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "originalId",
+    "description": "Original identifiers for the datasource",
+    "mode": "REPEATED",
+    "type": "STRING"
+  },
+  {
+    "name": "officialname",
+    "description": "The official name of the datasource",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "datauploadrestriction",
+    "description": "Upload restrictions applied by the datasource, as defined by re3data.org. One of {feeRequired, registration, other}",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "datasourcetype",
+    "mode": "NULLABLE",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "value",
+        "description": "The value expressed in the scheme (Journal)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "scheme",
+        "description": "The scheme used to express the value (i.e. pubsrepository::journal)",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "openairecompatibility",
+    "description": "OpenAIRE guidelines the data source comply with. See also https://guidelines.openaire.eu.",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "uploadrights",
+    "description": "Type of data upload. As defined by re3data.org: one of {open, restricted,closed}",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "description",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "englishname",
+    "description": "The English name of the datasource",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "releaseenddate",
+    "description": "Date when the data source went offline or stopped ingesting new research data. As defined by re3data.org",
+    "mode": "NULLABLE",
+    "type": "DATE"
+  },
+  {
+    "name": "releasestartdate",
+    "description": "Releasing date of the data source, as defined by re3data.org",
+    "mode": "NULLABLE",
+    "type": "DATE"
+  },
+  {
+    "name": "certificates",
+    "description": "The certificate, seal or standard the data source complies with. As defined by re3data.org.",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "pid",
+    "description": "Persistent identifiers of the datasource",
+    "mode": "REPEATED",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "value",
+        "description": "The value expressed in the scheme ",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      },
+      {
+        "name": "scheme",
+        "description": "The scheme used to express the value ",
+        "mode": "NULLABLE",
+        "type": "STRING"
+      }
+    ]
+  }
+]

--- a/database/schemas/organization.json
+++ b/database/schemas/organization.json
@@ -1,70 +1,70 @@
 [
-    {
-        "name": "alternativenames",
-        "description": "Alternative names that identify the organisation",
-        "type": "STRING",
-        "mode": "REPEATED"
-    },
-    {
-        "name": "country",
-        "description": "The organisation country",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-            {
-                "name": "code",
-                "description": "ISO 3166-1 alpha-2 country code (i.e. IT)",
-                "type": "STRING",
-                "mode": "NULLABLE"
-            },
-            {
-                "name": "label",
-                "description": "The label for that code (i.e. Italy)",
-                "type": "STRING",
-                "mode": "NULLABLE"
-            }
-        ]
-    },
-    {
-        "name": "id",
-        "description": "The OpenAIRE id for the organisation",
+  {
+    "name": "alternativenames",
+    "description": "Alternative names that identify the organisation",
+    "type": "STRING",
+    "mode": "REPEATED"
+  },
+  {
+    "name": "country",
+    "description": "The organisation country",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "code",
+        "description": "ISO 3166-1 alpha-2 country code (i.e. IT)",
         "type": "STRING",
         "mode": "NULLABLE"
-    },
-    {
-        "name": "legalname",
+      },
+      {
+        "name": "label",
+        "description": "The label for that code (i.e. Italy)",
         "type": "STRING",
         "mode": "NULLABLE"
-    },
-    {
-        "name": "legalshortname",
+      }
+    ]
+  },
+  {
+    "name": "id",
+    "description": "The OpenAIRE id for the organisation",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "legalname",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "legalshortname",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "pid",
+    "description": "Persistent identifiers for the organisation i.e. isni 0000000090326370",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "scheme",
+        "description": "The scheme of the identifier (i.e. isni)",
         "type": "STRING",
         "mode": "NULLABLE"
-    },
-    {
-        "name": "pid",
-        "description": "Persistent identifiers for the organisation i.e. isni 0000000090326370",
-        "type": "RECORD",
-        "mode": "REPEATED",
-        "fields": [
-            {
-                "name": "scheme",
-                "description": "The scheme of the identifier (i.e. isni)",
-                "type": "STRING",
-                "mode": "NULLABLE"
-            },
-            {
-                "name": "value",
-                "description": "The value in the schema (i.e. 0000000090326370)",
-                "type": "STRING",
-                "mode": "NULLABLE"
-            }
-        ]
-    },
-    {
-        "name": "websiteurl",
+      },
+      {
+        "name": "value",
+        "description": "The value in the schema (i.e. 0000000090326370)",
         "type": "STRING",
         "mode": "NULLABLE"
-    }
+      }
+    ]
+  },
+  {
+    "name": "websiteurl",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
 ]
     

--- a/database/schemas/otherresearchproduct.json
+++ b/database/schemas/otherresearchproduct.json
@@ -571,5 +571,25 @@
         "type": "STRING"
       }
     ]
+  },
+  {
+    "name": "isGreen",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "openAccessColor",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "isInDiamondJournal",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "publiclyFunded",
+    "mode": "NULLABLE",
+    "type": "BOOL"
   }
 ]

--- a/database/schemas/project.json
+++ b/database/schemas/project.json
@@ -66,30 +66,30 @@
     ]
   },
   {
-  "name": "granted",
-  "type": "RECORD",
-  "mode": "REPEATED",
-  "description": "The money granted to the project",
-  "fields": [
-    {
-      "name": "currency",
-      "type": "STRING",
-      "mode": "NULLABLE",
-      "description": "The currency of the granted amount (e.g. EUR)"
-    },
-    {
-      "name": "fundedamount",
-      "type": "FLOAT",
-      "mode": "NULLABLE",
-      "description": "The funded amount"
-    },
-    {
-      "name": "totalcost",
-      "type": "FLOAT",
-      "mode": "NULLABLE",
-      "description": "The money granted to the project"
-    }
-   ]
+    "name": "granted",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "The money granted to the project",
+    "fields": [
+      {
+        "name": "currency",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "The currency of the granted amount (e.g. EUR)"
+      },
+      {
+        "name": "fundedamount",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "The funded amount"
+      },
+      {
+        "name": "totalcost",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "The money granted to the project"
+      }
+    ]
   },
   {
     "name": "h2020programme",

--- a/database/schemas/publication.json
+++ b/database/schemas/publication.json
@@ -657,5 +657,25 @@
     "description": "Type of the result: one of 'publication', 'dataset', 'software', 'other' (see also https://api.openaire.eu/vocabularies/dnet:result_typologies)",
     "type": "STRING",
     "mode": "NULLABLE"
+  },
+  {
+    "name": "isGreen",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "openAccessColor",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "isInDiamondJournal",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "publiclyFunded",
+    "mode": "NULLABLE",
+    "type": "BOOL"
   }
 ]

--- a/database/schemas/relation.json
+++ b/database/schemas/relation.json
@@ -3,7 +3,7 @@
     "name": "provenance",
     "type": "RECORD",
     "mode": "NULLABLE",
-    "description" : "The reason why OpenAIRE holds the relation",
+    "description": "The reason why OpenAIRE holds the relation",
     "fields": [
       {
         "name": "provenance",
@@ -23,7 +23,7 @@
     "name": "reltype",
     "type": "RECORD",
     "mode": "NULLABLE",
-    "description" : "To represent the semantics of a relation between two entities",
+    "description": "To represent the semantics of a relation between two entities",
     "fields": [
       {
         "name": "name",
@@ -53,24 +53,24 @@
     "name": "target",
     "type": "STRING",
     "mode": "NULLABLE",
-    "description" : "The identifier of the target in the relation"
+    "description": "The identifier of the target in the relation"
   },
   {
     "name": "targetType",
     "type": "STRING",
     "mode": "NULLABLE",
-    "description" : "The entity type of the target in the relation"
+    "description": "The entity type of the target in the relation"
   },
   {
     "name": "validated",
     "type": "BOOLEAN",
     "mode": "NULLABLE",
-    "description":"True if the relation is related to a project and it has been collected from an authoritative source (i.e. the funder)"
+    "description": "True if the relation is related to a project and it has been collected from an authoritative source (i.e. the funder)"
   },
   {
     "name": "validationDate",
     "type": "DATE",
     "mode": "NULLABLE",
-    "description":"The date when the relation was collected from OpenAIRE"
+    "description": "The date when the relation was collected from OpenAIRE"
   }
 ]

--- a/database/schemas/software.json
+++ b/database/schemas/software.json
@@ -556,5 +556,25 @@
         "type": "STRING"
       }
     ]
+  },
+  {
+    "name": "isGreen",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "openAccessColor",
+    "mode": "NULLABLE",
+    "type": "STRING"
+  },
+  {
+    "name": "isInDiamondJournal",
+    "mode": "NULLABLE",
+    "type": "BOOL"
+  },
+  {
+    "name": "publiclyFunded",
+    "mode": "NULLABLE",
+    "type": "BOOL"
   }
 ]

--- a/main.py
+++ b/main.py
@@ -150,6 +150,7 @@ class OpenAIREWorkflow:
                 schema_file_path=table.schema_path,
                 write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
                 source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
+                ignore_unknown_values=True
             )
 
             print(f"Done uploading to table! {table.full_table_id}")

--- a/openaire/config.py
+++ b/openaire/config.py
@@ -140,7 +140,7 @@ def create_config(config_path: str) -> Tuple[CloudWorkspace, WorkflowConfig]:
             remove_nulls = None
 
         uri_prefix = f"gs://{cloud_workspace.bucket_id}/{cloud_workspace.bucket_folder}/{name}"
-        gcs_uri_pattern = f"{uri_prefix}/part-*_NR.json.gz" if remove_nulls else f"{uri_prefix}/part-*.json.gz"
+        gcs_uri_pattern = f"{uri_prefix}/*.json.gz"
 
         # Create table objects
         table = Table(

--- a/openaire/config.py
+++ b/openaire/config.py
@@ -17,15 +17,17 @@
 
 ### Read in config file and create the cloud workspace data classes.
 
-import os
-import yaml
-import pathlib
 import logging
-import pendulum
+import os
+import pathlib
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Tuple, List
+
+import pendulum
+import yaml
+
 from openaire.model import Table
-from dataclasses import dataclass
 
 
 @dataclass

--- a/openaire/model.py
+++ b/openaire/model.py
@@ -18,15 +18,8 @@ import os
 import pathlib
 import re
 from typing import Dict, Union, List, Optional
+
 from openaire.files import schema_folder as default_schema_folder
-
-PART_LIST_GZ_PATTERN = (
-    r"^part-\d{5}\.json\.gz$|^part-\d{5}-[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}-[\d|\w]{4}\.json\.gz$"
-)
-
-PART_LIST_GZ_NR_PATTERN = (
-    r"^part-\d{5}\.json\.gz$|^part-\d{5}-[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}-[\d|\w]{4}\.json\.gz$"
-)
 
 
 class Table:
@@ -111,7 +104,9 @@ class Table:
     def transform_files(self):
         files = []
         for file in os.listdir(self.part_location):
-            if (self.remove_nulls and re.match(r".+_NR\.json\.gz$", file)) or (not self.remove_nulls and re.match(r".+((?<!_NR)\.json\.gz)$", file)):
+            if (self.remove_nulls and re.match(r".+_NR\.json\.gz$", file)) or (
+                not self.remove_nulls and re.match(r".+((?<!_NR)\.json\.gz)$", file)
+            ):
                 files.append(os.path.join(self.part_location, file))
         files.sort()
         return files

--- a/openaire/model.py
+++ b/openaire/model.py
@@ -16,8 +16,17 @@
 
 import os
 import pathlib
+import re
 from typing import Dict, Union, List, Optional
 from openaire.files import schema_folder as default_schema_folder
+
+PART_LIST_GZ_PATTERN = (
+    r"^part-\d{5}\.json\.gz$|^part-\d{5}-[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}-[\d|\w]{4}\.json\.gz$"
+)
+
+PART_LIST_GZ_NR_PATTERN = (
+    r"^part-\d{5}\.json\.gz$|^part-\d{5}-[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}-[\d|\w]{4}\.json\.gz$"
+)
 
 
 class Table:
@@ -35,7 +44,7 @@ class Table:
         so the file to download is otherresearchproduct_1.tar
     :param remove_nulls: Columns of where suspect nulls are that cause issues with importing to Bigquery.
     :param local_part_list_gz: List of where all the part files are locally stored (for the upload step).
-    :param uri_part_list: List of all the uris of parts uploaded to Google Cloud Storage. 
+    :param uri_part_list: List of all the uris of parts uploaded to Google Cloud Storage.
 
     """
 
@@ -50,8 +59,6 @@ class Table:
         gcs_uri_pattern: str,
         alt_name: Optional[str] = None,
         remove_nulls: Optional[Union[str, List[str]]] = None,
-        local_part_list_gz: Optional[List[str]] = None,
-        uri_part_list: Optional[List[str]] = None,
     ):
         self.name = name
         self.num_parts = num_parts
@@ -59,15 +66,10 @@ class Table:
         self.full_table_id = full_table_id
         self.remove_nulls = remove_nulls
         self.alt_name = alt_name
-        self.local_part_list_gz = local_part_list_gz
-        self.uri_part_list = uri_part_list
-
         self.gcs_uri_pattern = gcs_uri_pattern
-
         self.download_folder = os.path.join(download_folder, name)
         self.decompress_folder = os.path.join(decompress_folder)
         self.part_location = os.path.join(decompress_folder, name)
-
         self.zenodo_name = alt_name if alt_name else name
 
     @property
@@ -94,3 +96,22 @@ class Table:
             )
 
         return downloads
+
+    @property
+    def extracted_files(self):
+        files = [
+            os.path.join(self.part_location, file)
+            for file in os.listdir(self.part_location)
+            if re.match(r".+((?<!_NR)\.json\.gz)$", file)
+        ]
+        files.sort()
+        return files
+
+    @property
+    def transform_files(self):
+        files = []
+        for file in os.listdir(self.part_location):
+            if (self.remove_nulls and re.match(r".+_NR\.json\.gz$", file)) or (not self.remove_nulls and re.match(r".+((?<!_NR)\.json\.gz)$", file)):
+                files.append(os.path.join(self.part_location, file))
+        files.sort()
+        return files


### PR DESCRIPTION
This PR updates the following:
* Format schemas.
* Add isGreen, openAccessColor, isInDiamondJournal and publiclyFunded to: dataset, publication, otherresearchproduct and software.
* Get lists of extracted and transformed files whenever requested (via a property) so that each task function (e.g. decompress, transform, gcs_upload etc) is not dependent on the previous task function running.
* Simplify file regex's and Google Cloud Storage URI pattern.